### PR TITLE
remove point stuffs

### DIFF
--- a/components/questions/QuestionCard.vue
+++ b/components/questions/QuestionCard.vue
@@ -5,7 +5,6 @@
         {{ `Question ${question}` }}
       </CardTitle>
       <CardDescription>
-        {{ `[${points} ${points > 1 ? 'points' : 'point'}]` }}
         <span class="text-theme-red">
           {{ isInvalid ? 'Please enter a valid number' : '' }}
         </span>
@@ -59,12 +58,10 @@ const props = defineProps([
   'mathContent',
   'extraInfo',
   'imageUrl',
-  'points',
 ]);
 
 const question = ref(props.question);
 const week = ref(props.week);
-const points = ref(props.points);
 
 // Random accent image (1 to 4)
 const randAccent = ref(Math.floor(Math.random() * 4) + 1);

--- a/components/questions/Tabs.vue
+++ b/components/questions/Tabs.vue
@@ -70,7 +70,6 @@
           :extraInfo="question.extra_info"
           :week="week"
           :imageUrl="question.image_url"
-          :points="question.points"
         />
 
         <!-- preview answer -->
@@ -201,9 +200,7 @@
                       >
                       <span class="text-sm text-gray-600">
                         {{ answersStore.getAnsweredCountForWeek(week) }} /
-                        {{
-                          answersStore.getTotalQuestionsForWeek(week)
-                        }}
+                        {{ answersStore.getTotalQuestionsForWeek(week) }}
                         answered
                       </span>
                     </div>


### PR DESCRIPTION
Very minimal change on the frontend, and the backend + supabase tables doesnt even need to be changed. To avoid breaking previous deployments and to allow future years to change the point amounts, we can just manually change all the questions to have a point value of 1 on the supabase (and perhaps in the upload system we may make in the future).